### PR TITLE
main_window: Add octet-stream mimetype

### DIFF
--- a/keepassgtk/main_window.py
+++ b/keepassgtk/main_window.py
@@ -143,6 +143,7 @@ class MainWindow(Gtk.ApplicationWindow):
         filter_text = Gtk.FileFilter()
         filter_text.set_name("Keepass 2 Database")
         filter_text.add_mime_type("application/x-keepass2")
+        filter_text.add_mime_type("application/octet-stream")
         filechooser_opening_dialog.add_filter(filter_text)
 
         response = filechooser_opening_dialog.run()


### PR DESCRIPTION
One of the mimetypes for Keepass Databases is application/octet-stream.
Because this was not added to the filter, databases were not properly
showing when trying to open them. This commit adds them to the filter.